### PR TITLE
Introduce Chapter type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # MentorIA
+
+This project provides an adaptive learning platform built with React.
+
+## Data Types
+
+Courses are described by the `Course` interface found in `project/src/types`.
+A course may optionally include structured `chapters` which are defined by the
+`Chapter` type. Each chapter lists its concepts so that teachers can create
+targeted practice sessions.

--- a/project/src/pages/ChapterSelectionPage.tsx
+++ b/project/src/pages/ChapterSelectionPage.tsx
@@ -3,13 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import Navigation from '../components/Navigation';
 import { BookOpen, Target } from 'lucide-react';
-
-interface Chapter {
-  id: string;
-  number: number;
-  title: string;
-  concepts: string[];
-}
+import { Chapter } from '../types';
 
 interface CourseFramework {
   id: string;

--- a/project/src/pages/CourseSelectionPage.tsx
+++ b/project/src/pages/CourseSelectionPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Course } from '../types';
+import { Course, Chapter } from '../types';
 import CourseCard from '../components/CourseCard';
 import Navigation from '../components/Navigation';
 import { getCourses } from '../services/storageService';
@@ -11,12 +11,7 @@ interface CourseFramework {
   id: string;
   name: string;
   description: string;
-  chapters: Array<{
-    id: string;
-    number: number;
-    title: string;
-    concepts: string[];
-  }>;
+  chapters: Chapter[];
   teacherId: string;
 }
 

--- a/project/src/pages/TeacherRegistrationPage.tsx
+++ b/project/src/pages/TeacherRegistrationPage.tsx
@@ -3,13 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useUser } from '../context/UserContext';
 import { BookOpen, Plus, Trash2, Edit3 } from 'lucide-react';
-
-interface Chapter {
-  id: string;
-  number: number;
-  title: string;
-  concepts: string[];
-}
+import { Chapter } from '../types';
 
 interface CourseFramework {
   id: string;

--- a/project/src/types/index.ts
+++ b/project/src/types/index.ts
@@ -3,6 +3,17 @@ export interface Course {
   name: string;
   description: string;
   classes?: CourseClass[];
+  /**
+   * Optional structured chapters for teacher-designed courses.
+   */
+  chapters?: Chapter[];
+}
+
+export interface Chapter {
+  id: string;
+  number: number;
+  title: string;
+  concepts: string[];
 }
 
 export interface CourseClass {


### PR DESCRIPTION
## Summary
- define `Chapter` interface
- allow `Course` to include optional chapters
- reference `Chapter` type in teacher and chapter pages
- document the new course structure in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ad70fcf4c8333b24400b242fcde0c