### PR TITLE
Fix course deletion to remove questions

### DIFF
--- a/project/src/services/storageService.ts
+++ b/project/src/services/storageService.ts
@@ -56,6 +56,9 @@ export const deleteCourse = (courseId: string): void => {
   let courses = getCourses();
   courses = courses.filter(c => c.id !== courseId);
   localStorage.setItem(STORAGE_KEYS.COURSES, JSON.stringify(courses));
+  let questions = getQuestions();
+  questions = questions.filter(q => q.courseId !== courseId);
+  localStorage.setItem(STORAGE_KEYS.QUESTIONS, JSON.stringify(questions));
 };
 
 // Questions


### PR DESCRIPTION
## Summary
- cascade question deletion in storage service when removing courses

## Testing
- `node /tmp/verifyDeletion2.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ad5d7047c833386cc06ce759d0fb2