### PR TITLE
Add teacher course builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Courses are described by the `Course` interface found in `project/src/types`.
 A course may optionally include structured `chapters` which are defined by the
 `Chapter` type. Each chapter lists its concepts so that teachers can create
 targeted practice sessions.
+
+The `structuredCourse.ts` file contains a simplified hierarchy used during
+teacher onboarding. Courses built with the new page return a `Course` object
+containing nested `chapters`, `subtopics`, and `concepts`.

--- a/project/src/components/ChapterForm.tsx
+++ b/project/src/components/ChapterForm.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Chapter, Subtopic } from '../types/structuredCourse';
+import SubtopicForm from './SubtopicForm';
+import { v4 as uuidv4 } from 'uuid';
+
+interface ChapterFormProps {
+  chapter: Chapter;
+  onChange: (chapter: Chapter) => void;
+  onDelete: () => void;
+}
+
+const ChapterForm: React.FC<ChapterFormProps> = ({ chapter, onChange, onDelete }) => {
+  const handleSubtopicChange = (index: number, updated: Subtopic) => {
+    const newSubtopics = [...chapter.subtopics];
+    newSubtopics[index] = updated;
+    onChange({ ...chapter, subtopics: newSubtopics });
+  };
+
+  const addSubtopic = () => {
+    onChange({
+      ...chapter,
+      subtopics: [...chapter.subtopics, { id: uuidv4(), title: '', concepts: [] }],
+    });
+  };
+
+  const deleteSubtopic = (index: number) => {
+    const newSubtopics = chapter.subtopics.filter((_, i) => i !== index);
+    onChange({ ...chapter, subtopics: newSubtopics });
+  };
+
+  return (
+    <div className="p-4 border rounded-lg mb-6">
+      <div className="flex justify-between items-center mb-3">
+        <input
+          type="text"
+          value={chapter.title}
+          onChange={(e) => onChange({ ...chapter, title: e.target.value })}
+          placeholder="Chapter title"
+          className="flex-1 p-2 border rounded-lg"
+        />
+        <button type="button" onClick={onDelete} className="ml-2 text-red-600">
+          Remove
+        </button>
+      </div>
+      {chapter.subtopics.map((subtopic, index) => (
+        <SubtopicForm
+          key={subtopic.id}
+          subtopic={subtopic}
+          onChange={(s) => handleSubtopicChange(index, s)}
+          onDelete={() => deleteSubtopic(index)}
+        />
+      ))}
+      <button type="button" onClick={addSubtopic} className="text-sm text-primary-600 mt-2">
+        + Add Subtopic
+      </button>
+    </div>
+  );
+};
+
+export default ChapterForm;

--- a/project/src/components/ConceptForm.tsx
+++ b/project/src/components/ConceptForm.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Concept } from '../types/structuredCourse';
+
+interface ConceptFormProps {
+  concept: Concept;
+  onChange: (concept: Concept) => void;
+  onDelete: () => void;
+}
+
+const ConceptForm: React.FC<ConceptFormProps> = ({ concept, onChange, onDelete }) => {
+  return (
+    <div className="flex items-center mb-2">
+      <input
+        type="text"
+        value={concept.title}
+        onChange={(e) => onChange({ ...concept, title: e.target.value })}
+        placeholder="Concept title"
+        className="flex-1 p-2 border rounded-lg"
+      />
+      <button type="button" onClick={onDelete} className="ml-2 text-red-600">
+        Remove
+      </button>
+    </div>
+  );
+};
+
+export default ConceptForm;

--- a/project/src/components/SubtopicForm.tsx
+++ b/project/src/components/SubtopicForm.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Subtopic, Concept } from '../types/structuredCourse';
+import ConceptForm from './ConceptForm';
+import { v4 as uuidv4 } from 'uuid';
+
+interface SubtopicFormProps {
+  subtopic: Subtopic;
+  onChange: (subtopic: Subtopic) => void;
+  onDelete: () => void;
+}
+
+const SubtopicForm: React.FC<SubtopicFormProps> = ({ subtopic, onChange, onDelete }) => {
+  const handleConceptChange = (index: number, updated: Concept) => {
+    const newConcepts = [...subtopic.concepts];
+    newConcepts[index] = updated;
+    onChange({ ...subtopic, concepts: newConcepts });
+  };
+
+  const addConcept = () => {
+    onChange({
+      ...subtopic,
+      concepts: [...subtopic.concepts, { id: uuidv4(), title: '' }],
+    });
+  };
+
+  const deleteConcept = (index: number) => {
+    const newConcepts = subtopic.concepts.filter((_, i) => i !== index);
+    onChange({ ...subtopic, concepts: newConcepts });
+  };
+
+  return (
+    <div className="p-4 border rounded-lg mb-4">
+      <div className="flex justify-between items-center mb-2">
+        <input
+          type="text"
+          value={subtopic.title}
+          onChange={(e) => onChange({ ...subtopic, title: e.target.value })}
+          placeholder="Subtopic title"
+          className="flex-1 p-2 border rounded-lg"
+        />
+        <button type="button" onClick={onDelete} className="ml-2 text-red-600">
+          Remove
+        </button>
+      </div>
+      {subtopic.concepts.map((concept, index) => (
+        <ConceptForm
+          key={concept.id}
+          concept={concept}
+          onChange={(c) => handleConceptChange(index, c)}
+          onDelete={() => deleteConcept(index)}
+        />
+      ))}
+      <button type="button" onClick={addConcept} className="text-sm text-primary-600 mt-2">
+        + Add Concept
+      </button>
+    </div>
+  );
+};
+
+export default SubtopicForm;

--- a/project/src/pages/TeacherOnboardingPage.tsx
+++ b/project/src/pages/TeacherOnboardingPage.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { v4 as uuidv4 } from 'uuid';
+import Navigation from '../components/Navigation';
+import ChapterForm from '../components/ChapterForm';
+import { Course, Chapter } from '../types/structuredCourse';
+
+const TeacherOnboardingPage: React.FC = () => {
+  const [title, setTitle] = useState('');
+  const [chapters, setChapters] = useState<Chapter[]>([]);
+
+  const handleChapterChange = (index: number, updated: Chapter) => {
+    const newChapters = [...chapters];
+    newChapters[index] = updated;
+    setChapters(newChapters);
+  };
+
+  const addChapter = () => {
+    setChapters([...chapters, { id: uuidv4(), title: '', subtopics: [] }]);
+  };
+
+  const deleteChapter = (index: number) => {
+    setChapters(chapters.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const course: Course = { id: uuidv4(), title, chapters };
+    console.log(course);
+    alert(JSON.stringify(course, null, 2));
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <div className="max-w-3xl mx-auto p-4">
+        <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.3 }}>
+          <h1 className="text-2xl font-bold mb-4">Create Course</h1>
+          <form onSubmit={handleSubmit} className="bg-white p-4 rounded-lg border space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Course Title</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full p-2 border rounded-lg"
+                required
+              />
+            </div>
+            <div>
+              <h2 className="font-semibold mb-2">Chapters</h2>
+              {chapters.map((chapter, index) => (
+                <ChapterForm
+                  key={chapter.id}
+                  chapter={chapter}
+                  onChange={(c) => handleChapterChange(index, c)}
+                  onDelete={() => deleteChapter(index)}
+                />
+              ))}
+              <button type="button" onClick={addChapter} className="text-sm text-primary-600">
+                + Add Chapter
+              </button>
+            </div>
+            <div className="pt-4">
+              <button type="submit" className="px-4 py-2 bg-primary-600 text-white rounded-lg">
+                Save Course
+              </button>
+            </div>
+          </form>
+        </motion.div>
+      </div>
+    </div>
+  );
+};
+
+export default TeacherOnboardingPage;

--- a/project/src/types/structuredCourse.ts
+++ b/project/src/types/structuredCourse.ts
@@ -1,0 +1,22 @@
+export interface Concept {
+  id: string;
+  title: string;
+}
+
+export interface Subtopic {
+  id: string;
+  title: string;
+  concepts: Concept[];
+}
+
+export interface Chapter {
+  id: string;
+  title: string;
+  subtopics: Subtopic[];
+}
+
+export interface Course {
+  id: string;
+  title: string;
+  chapters: Chapter[];
+}


### PR DESCRIPTION
## Summary
- create `structuredCourse` interfaces for nested course data
- add new `ConceptForm`, `SubtopicForm`, and `ChapterForm` components
- implement `TeacherOnboardingPage` with dynamic nested course controls
- document nested course hierarchy in README

## Testing
- `npm test`
- `npm run lint` *(fails: 7 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685b1fd44c10833398f4f81255ed54e7