### PR TITLE
Add accounting input components

### DIFF
--- a/project/src/components/EntryInput.jsx
+++ b/project/src/components/EntryInput.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+/**
+ * EntryInput lets the user select debit and credit accounts for a journal
+ * entry and specify a single amount. When no list of accounts is supplied it
+ * falls back to a simple text input which can be used for plain questions.
+ *
+ * Props:
+ *   - accounts: array of account names.
+ *   - value: { debits: string[], credits: string[], amount: number|string, text: string }
+ *   - onChange: callback fired with the updated value object.
+ */
+function EntryInput({ accounts = [], value = {}, onChange }) {
+  const {
+    debits = [],
+    credits = [],
+    amount = '',
+    text = ''
+  } = value;
+
+  const update = (field, newValue) => {
+    onChange({ ...value, [field]: newValue });
+  };
+
+  const handleSelect = (field, options) => {
+    const selected = Array.from(options).map((o) => o.value);
+    update(field, selected);
+  };
+
+  if (accounts.length === 0) {
+    return (
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Respuesta</label>
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => update('text', e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">Cuenta(s) Deudora</label>
+        <select
+          multiple
+          value={debits}
+          onChange={(e) => handleSelect('debits', e.target.selectedOptions)}
+          className="w-full p-2 border rounded h-32"
+        >
+          {accounts.map((acc) => (
+            <option key={acc} value={acc}>
+              {acc}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Cuenta(s) Acreedora</label>
+        <select
+          multiple
+          value={credits}
+          onChange={(e) => handleSelect('credits', e.target.selectedOptions)}
+          className="w-full p-2 border rounded h-32"
+        >
+          {accounts.map((acc) => (
+            <option key={acc} value={acc}>
+              {acc}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Monto</label>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => update('amount', e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default EntryInput;

--- a/project/src/components/TAccountEditor.jsx
+++ b/project/src/components/TAccountEditor.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+/**
+ * TAccountEditor renders a dynamic table used for Cuenta T Maestra or
+ * Estados Financieros por Unidad de Fomento (EFUF). Each row represents an
+ * entry with the following fields:
+ *  - concept: description of the transaction
+ *  - amount: numeric value
+ *  - type: whether the value goes to debit or credit
+ *  - category: Operación, Inversión or Financiamiento
+ *
+ * Props:
+ *   - rows: array of row objects
+ *   - onChange: callback(rows) invoked whenever a row is edited
+ */
+function TAccountEditor({ rows = [], onChange }) {
+  const handleRowChange = (index, field, value) => {
+    const updated = rows.map((row, i) =>
+      i === index ? { ...row, [field]: value } : row
+    );
+    onChange(updated);
+  };
+
+  const addRow = () => {
+    onChange([
+      ...rows,
+      { concept: '', amount: '', type: 'debit', category: 'Operacion' }
+    ]);
+  };
+
+  const removeRow = (index) => {
+    const updated = rows.filter((_, i) => i !== index);
+    onChange(updated);
+  };
+
+  return (
+    <div>
+      <table className="min-w-full text-sm border">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="p-2 border">Concepto</th>
+            <th className="p-2 border">Monto</th>
+            <th className="p-2 border">Debe/Haber</th>
+            <th className="p-2 border">Categoría</th>
+            <th className="p-2 border" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index} className="odd:bg-white even:bg-gray-50">
+              <td className="p-2 border">
+                <input
+                  type="text"
+                  className="w-full p-1 border rounded"
+                  value={row.concept}
+                  onChange={(e) => handleRowChange(index, 'concept', e.target.value)}
+                />
+              </td>
+              <td className="p-2 border">
+                <input
+                  type="number"
+                  className="w-full p-1 border rounded"
+                  value={row.amount}
+                  onChange={(e) => handleRowChange(index, 'amount', e.target.value)}
+                />
+              </td>
+              <td className="p-2 border">
+                <select
+                  className="w-full p-1 border rounded"
+                  value={row.type}
+                  onChange={(e) => handleRowChange(index, 'type', e.target.value)}
+                >
+                  <option value="debit">Debe</option>
+                  <option value="credit">Haber</option>
+                </select>
+              </td>
+              <td className="p-2 border">
+                <select
+                  className="w-full p-1 border rounded"
+                  value={row.category}
+                  onChange={(e) =>
+                    handleRowChange(index, 'category', e.target.value)
+                  }
+                >
+                  <option value="Operacion">Operación</option>
+                  <option value="Inversion">Inversión</option>
+                  <option value="Financiamiento">Financiamiento</option>
+                </select>
+              </td>
+              <td className="p-2 border text-center">
+                <button
+                  type="button"
+                  onClick={() => removeRow(index)}
+                  className="text-red-600"
+                >
+                  Eliminar
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        type="button"
+        onClick={addRow}
+        className="mt-3 px-4 py-2 bg-primary-600 text-white rounded"
+      >
+        Agregar fila
+      </button>
+    </div>
+  );
+}
+
+export default TAccountEditor;


### PR DESCRIPTION
## Summary
- add EntryInput component for selecting debit/credit accounts or text answers
- add TAccountEditor component for editing Cuenta T/EFUF tables

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec62cfbd0833384b4831f619816e5