### PR TITLE
Add financial statement display components

### DIFF
--- a/project/src/components/AdditionalInfo.jsx
+++ b/project/src/components/AdditionalInfo.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+const AdditionalInfo = ({ items = [] }) => {
+  const [openIndex, setOpenIndex] = useState(null);
+
+  const toggle = (index) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <div className="space-y-2">
+      {items.map((item, index) => (
+        <div key={index} className="border rounded-md">
+          <button
+            type="button"
+            onClick={() => toggle(index)}
+            className="w-full p-2 text-left font-medium bg-gray-100"
+          >
+            {item.title}
+          </button>
+          {openIndex === index && (
+            <div className="p-2 bg-white border-t">
+              {typeof item.content === 'string' ? <p>{item.content}</p> : item.content}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default AdditionalInfo;

--- a/project/src/components/BalanceSheet.jsx
+++ b/project/src/components/BalanceSheet.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+const BalanceSheet = ({ year, data = {} }) => {
+  const { assets = [], liabilities = [], equity = [] } = data;
+
+  const total = (arr) => arr.reduce((sum, item) => sum + (item.amount || 0), 0);
+
+  const renderSection = (title, items) => (
+    <table className="min-w-full divide-y divide-gray-200 text-sm mb-4">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 text-left font-medium text-gray-700" colSpan="2">
+            {title}
+          </th>
+        </tr>
+      </thead>
+      <tbody className="bg-white divide-y divide-gray-200">
+        {items.map((item, idx) => (
+          <tr key={idx}>
+            <td className="px-4 py-2">{item.label}</td>
+            <td className="px-4 py-2 text-right">{item.amount.toLocaleString()}</td>
+          </tr>
+        ))}
+        <tr>
+          <td className="px-4 py-2 font-medium">Total {title.toLowerCase()}</td>
+          <td className="px-4 py-2 text-right font-medium">
+            {total(items).toLocaleString()}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+
+  return (
+    <div>
+      <h2 className="text-lg font-semibold mb-2">Balance General {year}</h2>
+      {renderSection('Activos', assets)}
+      {renderSection('Pasivos', liabilities)}
+      {renderSection('Patrimonio', equity)}
+    </div>
+  );
+};
+
+export default BalanceSheet;

--- a/project/src/components/IncomeStatement.jsx
+++ b/project/src/components/IncomeStatement.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const IncomeStatement = ({ year = 2023, lines = [] }) => (
+  <div className="overflow-x-auto">
+    <h2 className="text-lg font-semibold mb-2">Estado de Resultados {year}</h2>
+    <table className="min-w-full divide-y divide-gray-200 text-sm">
+      <thead className="bg-gray-50">
+        <tr>
+          <th className="px-4 py-2 text-left font-medium text-gray-700">Concepto</th>
+          <th className="px-4 py-2 text-right font-medium text-gray-700">Monto</th>
+        </tr>
+      </thead>
+      <tbody className="bg-white divide-y divide-gray-200">
+        {lines.map((line, idx) => (
+          <tr key={idx}>
+            <td className="px-4 py-2">{line.label}</td>
+            <td className="px-4 py-2 text-right">{line.amount.toLocaleString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default IncomeStatement;

--- a/project/src/components/Instructions.jsx
+++ b/project/src/components/Instructions.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Instructions = ({ text }) => (
+  <div className="bg-white p-4 rounded-md shadow mb-4">
+    <h2 className="text-xl font-semibold mb-2">Instrucciones</h2>
+    {typeof text === 'string' ? <p>{text}</p> : text}
+  </div>
+);
+
+export default Instructions;


### PR DESCRIPTION
## Summary
- add Instructions, AdditionalInfo, IncomeStatement and BalanceSheet components
- these components render instructional text, accordion info items, a basic income statement, and a balance sheet with section totals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec62c0270833381810dadd43d03f8