### PR TITLE
Add Accounting course and routing

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -16,6 +16,7 @@ import TeacherDashboardPage from './pages/TeacherDashboardPage';
 import CourseOnboardingPage from './pages/CourseOnboardingPage';
 import TeacherRegistrationPage from './pages/TeacherRegistrationPage';
 import ChapterSelectionPage from './pages/ChapterSelectionPage';
+import AccountingCourse from './pages/AccountingCourse';
 
 function App() {
   useEffect(() => {
@@ -29,6 +30,7 @@ function App() {
           <Route path="/" element={<WelcomePage />} />
           <Route path="/courses" element={<CourseSelectionPage />} />
           <Route path="/vark/:courseId" element={<VARKQuestionnairePage />} />
+          <Route path="/accounting" element={<AccountingCourse />} />
           <Route path="/diagnostic/:courseId" element={<DiagnosticPage />} />
           <Route path="/results/:courseId" element={<ResultsPage />} />
           <Route path="/onboarding/:courseId" element={<CourseOnboardingPage />} />

--- a/project/src/data/initialData.ts
+++ b/project/src/data/initialData.ts
@@ -31,6 +31,11 @@ export const initialCourses: Course[] = [
     name: 'Estad\u00edstica',
     description: 'An\u00e1lisis e interpretaci\u00f3n de datos',
   },
+  {
+    id: 'accounting',
+    name: 'Contabilidad',
+    description: 'Curso de contabilidad b\u00e1sica',
+  },
 ];
 
 export const initialQuestions: Question[] = [

--- a/project/src/pages/CourseSelectionPage.tsx
+++ b/project/src/pages/CourseSelectionPage.tsx
@@ -30,7 +30,11 @@ const CourseSelectionPage: React.FC = () => {
   }, []);
   
   const handleSelectStandardCourse = (courseId: string) => {
-    navigate(`/vark/${courseId}`);
+    if (courseId === 'accounting') {
+      navigate('/accounting');
+    } else {
+      navigate(`/vark/${courseId}`);
+    }
   };
   
   const handleSelectFrameworkCourse = (courseId: string) => {


### PR DESCRIPTION
## Summary
- include accounting course in `initialData`
- add AccountingCourse import and route in `App`
- direct accounting selections to `/accounting`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ecc08454483338b6a4bbfa6fb9914