### PR TITLE
Add Accounting course page and route

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -16,6 +16,7 @@ import TeacherDashboardPage from './pages/TeacherDashboardPage';
 import CourseOnboardingPage from './pages/CourseOnboardingPage';
 import TeacherRegistrationPage from './pages/TeacherRegistrationPage';
 import ChapterSelectionPage from './pages/ChapterSelectionPage';
+import AccountingCourse from './pages/AccountingCourse';
 
 function App() {
   useEffect(() => {
@@ -36,6 +37,7 @@ function App() {
           <Route path="/practice/:courseId" element={<PracticeModePage />} />
           <Route path="/summary/:sessionId" element={<SessionSummaryPage />} />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/contabilidad" element={<AccountingCourse />} />
           <Route path="/teacher" element={<TeacherDashboardPage />} />
           <Route path="/teacher-registration" element={<TeacherRegistrationPage />} />
           <Route path="/logout" element={<Navigate to="/" />} />

--- a/project/src/pages/AccountingCourse.tsx
+++ b/project/src/pages/AccountingCourse.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Navigation from '../components/Navigation';
+
+const AccountingCourse: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Curso de Contabilidad</h1>
+        <p className="text-gray-600">Próximamente disponible.</p>
+      </div>
+    </div>
+  );
+};
+
+export default AccountingCourse;

--- a/project/src/pages/CourseSelectionPage.tsx
+++ b/project/src/pages/CourseSelectionPage.tsx
@@ -36,6 +36,16 @@ const CourseSelectionPage: React.FC = () => {
   const handleSelectFrameworkCourse = (courseId: string) => {
     navigate(`/chapters/${courseId}`);
   };
+
+  const handleAccountingCourse = () => {
+    navigate('/contabilidad');
+  };
+
+  const accountingCourse: Course = {
+    id: 'contabilidad',
+    name: 'Contabilidad',
+    description: 'Conceptos b\u00e1sicos de contabilidad',
+  };
   
   return (
     <div className="min-h-screen bg-gray-50">
@@ -105,6 +115,11 @@ const CourseSelectionPage: React.FC = () => {
                       onSelect={handleSelectStandardCourse}
                     />
                   ))}
+                  <CourseCard
+                    key={accountingCourse.id}
+                    course={accountingCourse}
+                    onSelect={handleAccountingCourse}
+                  />
                 </div>
               </>
             )}


### PR DESCRIPTION
## Summary
- create `AccountingCourse` page with placeholder content
- add route for `/contabilidad`
- show Accounting course in course selection

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ec62df11c833398925d669b710832