### PR TITLE
Improve Contabilidad exercise UX

### DIFF
--- a/project/src/components/ExerciseDetail.jsx
+++ b/project/src/components/ExerciseDetail.jsx
@@ -1,0 +1,179 @@
+import React, { useMemo, useState } from 'react';
+import AdditionalInfo from './AdditionalInfo';
+import EntryInput from './EntryInput';
+import TAccountEditor from './TAccountEditor';
+import IncomeStatement from './IncomeStatement';
+
+/**
+ * ExerciseDetail displays the full context for an accounting exercise and
+ * optionally the list of items/questions once the user starts the exercise.
+ *
+ * Props:
+ *   - exercise: object containing title, context_text, balance sheets, etc.
+ */
+function ExerciseDetail({ exercise }) {
+  const [started, setStarted] = useState(false);
+  const [responses, setResponses] = useState({});
+
+  if (!exercise) return null;
+
+  // Collect unique account names from balance data for EntryInput selects
+  const accounts = useMemo(() => {
+    const b2022 = exercise.balance_2022 || [];
+    const b2023 = exercise.balance_2023 || [];
+    const set = new Set([...b2022, ...b2023].map((b) => b.account));
+    return Array.from(set);
+  }, [exercise]);
+
+  const handleChange = (id, value) => {
+    setResponses((prev) => ({ ...prev, [id]: value }));
+  };
+
+  // Helper to render balances grouped by classification
+  const renderBalance = (year, entries = [], totals = {}) => {
+    const groups = entries.reduce((acc, item) => {
+      acc[item.classification] = acc[item.classification] || [];
+      acc[item.classification].push(item);
+      return acc;
+    }, {});
+
+    return (
+      <div className="bg-white p-4 rounded-md shadow mb-4">
+        <h2 className="text-lg font-semibold mb-2">Balance {year}</h2>
+        {Object.entries(groups).map(([section, items]) => (
+          <table
+            key={section}
+            className="min-w-full text-sm mb-4 border divide-y divide-gray-200"
+          >
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="p-2 text-left" colSpan="2">
+                  {section}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it, idx) => (
+                <tr key={idx} className="odd:bg-white even:bg-gray-50">
+                  <td className="p-2 border">{it.account}</td>
+                  <td className="p-2 border text-right">
+                    {it.amount.toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+              {totals[section] !== undefined && (
+                <tr className="font-medium">
+                  <td className="p-2 border">Total {section}</td>
+                  <td className="p-2 border text-right">
+                    {totals[section].toLocaleString()}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        ))}
+        {totals['Total Activo'] !== undefined && (
+          <div className="flex justify-between font-semibold mt-2 border-t pt-2">
+            <span>Total Activo</span>
+            <span>{totals['Total Activo'].toLocaleString()}</span>
+          </div>
+        )}
+        {totals['Total Pasivo y Patrimonio'] !== undefined && (
+          <div className="flex justify-between font-semibold">
+            <span>Total Pasivo y Patrimonio</span>
+            <span>{totals['Total Pasivo y Patrimonio'].toLocaleString()}</span>
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderItemInput = (item) => {
+    if (item.t_account || item.formal_statement) {
+      const rows = responses[item.item_id] || [];
+      return (
+        <TAccountEditor
+          rows={rows}
+          onChange={(rows) => handleChange(item.item_id, rows)}
+        />
+      );
+    }
+
+    if (item.item_id && item.item_id.startsWith('ENTRY_')) {
+      const value = responses[item.item_id] || {};
+      return (
+        <EntryInput
+          accounts={accounts}
+          value={value}
+          onChange={(val) => handleChange(item.item_id, val)}
+        />
+      );
+    }
+
+    const value = responses[item.item_id] || '';
+    return (
+      <textarea
+        className="w-full p-2 border rounded"
+        rows={4}
+        value={value}
+        onChange={(e) => handleChange(item.item_id, e.target.value)}
+      />
+    );
+  };
+
+  const additional =
+    exercise.additional_info?.map((info, i) => ({
+      title: `Información ${i + 1}`,
+      content: info.text,
+    })) || [];
+
+  return (
+    <div className="space-y-4">
+      {/* Context always visible */}
+      <h1 className="text-2xl font-bold">{exercise.title}</h1>
+      {exercise.context_text && <p>{exercise.context_text}</p>}
+      {renderBalance('2022', exercise.balance_2022, exercise.section_totals_2022)}
+      {renderBalance('2023', exercise.balance_2023, exercise.section_totals)}
+      {exercise.income_statement_2023 && (
+        <IncomeStatement
+          year={2023}
+          lines={exercise.income_statement_2023.lines || []}
+        />
+      )}
+      {additional.length > 0 && <AdditionalInfo items={additional} />}
+      {exercise.instructions && exercise.instructions.length > 0 && (
+        <div className="bg-white p-4 rounded-md shadow">
+          <h2 className="text-xl font-semibold mb-2">Instrucciones</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {exercise.instructions.map((inst) => (
+              <li key={inst.id}>{inst.text}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {!started && (
+        <button
+          type="button"
+          onClick={() => setStarted(true)}
+          className="px-4 py-2 bg-primary-600 text-white rounded"
+        >
+          Start Exercise
+        </button>
+      )}
+
+      {started && (
+        <div className="space-y-6 mt-4">
+          {exercise.items?.map((item) => (
+            <div key={item.item_id} className="bg-white p-4 rounded-md shadow">
+              <p className="mb-2 font-medium">{item.prompt}</p>
+              {renderItemInput(item)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ExerciseDetail;

--- a/project/src/pages/AccountingCourse.jsx
+++ b/project/src/pages/AccountingCourse.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Navigation from '../components/Navigation';
+import ExerciseDetail from '../components/ExerciseDetail';
 
 /**
  * AccountingCourse
@@ -12,31 +13,27 @@ import Navigation from '../components/Navigation';
 export default function AccountingCourse() {
   const [exercises, setExercises] = useState([]); // Loaded exercise data
   const [selectedId, setSelectedId] = useState(null); // Current exercise ID
-  const [responses, setResponses] = useState({}); // Map of answers by exercise
 
   // Load JSON on mount
   useEffect(() => {
     fetch('/preguntas-contabilidad.json')
       .then((res) => res.json())
       .then((data) => {
-        // Expect an array of exercises; fall back to []
-        if (Array.isArray(data)) setExercises(data);
+        // Support object or array structure
+        if (Array.isArray(data)) {
+          setExercises(data);
+        } else if (data) {
+          setExercises([data]);
+        }
       })
       .catch((err) => {
         console.error('Failed to load accounting questions:', err);
       });
   }, []);
 
-  const selectedExercise = exercises.find((ex) => ex.id === selectedId);
-
-  const handleChange = (id, value) => {
-    setResponses((prev) => ({ ...prev, [id]: value }));
-  };
-
-  const handleSubmit = () => {
-    // Log the stored answers to the console
-    console.log('Submitted answers:', responses);
-  };
+  const selectedExercise = exercises.find(
+    (ex, idx) => (ex.case_id || ex.id || idx) === selectedId
+  );
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -46,47 +43,34 @@ export default function AccountingCourse() {
         <aside className="w-64 bg-white border-r border-gray-200 p-4 hidden md:block">
           <h2 className="text-lg font-semibold mb-4">Exercises</h2>
           <ul className="space-y-2">
-            {exercises.map((ex) => (
-              <li key={ex.id}>
-                <button
-                  onClick={() => setSelectedId(ex.id)}
-                  className={`w-full text-left px-3 py-2 rounded-md transition-colors ${selectedId === ex.id ? 'bg-primary-100 text-primary-700' : 'hover:bg-gray-100'}`}
-                >
-                  {ex.title}
-                </button>
-              </li>
-            ))}
+            {exercises.map((ex, idx) => {
+              const id = ex.case_id || ex.id || idx;
+              const title = ex.title || ex.item_id || `Ejercicio ${idx + 1}`;
+              return (
+                <li key={id}>
+                  <button
+                    onClick={() => setSelectedId(id)}
+                    className={`w-full text-left px-3 py-2 rounded-md transition-colors ${
+                      selectedId === id
+                        ? 'bg-primary-100 text-primary-700'
+                        : 'hover:bg-gray-100'
+                    }`}
+                  >
+                    {title}
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         </aside>
 
         {/* Detail view */}
-        <main className="flex-1 p-4">
+        <main className="flex-1 p-4 space-y-4">
           {selectedExercise ? (
-            <div className="space-y-4">
-              <h1 className="text-2xl font-bold">{selectedExercise.title}</h1>
-              {/* Placeholder for exercise details */}
-              <div className="bg-white p-4 rounded shadow">
-                <pre className="whitespace-pre-wrap text-sm">{selectedExercise.details || 'No details provided.'}</pre>
-                <textarea
-                  className="mt-3 w-full border rounded p-2"
-                  rows={4}
-                  value={responses[selectedId] || ''}
-                  onChange={(e) => handleChange(selectedId, e.target.value)}
-                  placeholder="Type your answer here"
-                />
-              </div>
-            </div>
+            <ExerciseDetail exercise={selectedExercise} />
           ) : (
             <p className="text-gray-500">Select an exercise from the list.</p>
           )}
-
-          {/* Submit answers */}
-          <button
-            onClick={handleSubmit}
-            className="mt-6 px-6 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700"
-          >
-            Submit
-          </button>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `ExerciseDetail` to show context first and reveal questions on demand
- update `AccountingCourse` to use the new component and support JSON object data

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ece2d87348333bed8252c65b97b94